### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using this method, I was able to reduce my Signal backup size by about 80% (from
 
 1. Dump the unencrypted backup components to disk:
 
-`signalbackups-tools [backupfile] [password] --output [directory]`
+`signalbackup-tools [backupfile] [password] --output [directory]`
 
 2. Process message attachments:
 


### PR DESCRIPTION
This PR fixes a small typo in the `signalbackup-tools` command, probably rooted in the readme of that project itself (see https://github.com/bepaald/signalbackup-tools/pull/225).

As a side note, thanks a lot for this nifty script! As promised, I was able to reduce my backup file from 5.1 GiB to 1.0 GiB (~80 %).